### PR TITLE
 Fixed Bugs: marker deletion crash. Remove center point of livox point cloud.

### DIFF
--- a/src/livox_hikcamera_cal/include/livox_hikcamera_cal/pointcloud2_opr/point_cloud_process.h
+++ b/src/livox_hikcamera_cal/include/livox_hikcamera_cal/pointcloud2_opr/point_cloud_process.h
@@ -54,9 +54,9 @@ namespace livox_hikcamera_cal
                 pcl::PointCloud<pcl::PointXYZI>::Ptr get3DRectCorners();
 
 
-                void boxFilter(Eigen::Vector4f min_point, Eigen::Vector4f max_point);
+                void boxFilter(Eigen::Vector4f min_point, Eigen::Vector4f max_point, bool negetive=false);
                 void boxFilter(Eigen::Vector3f box_center, float length_x, float length_y, float length_z,
-                                float angle_x=0.0, float angle_y=0.0, float angle_z=0.0);
+                                float angle_x=0.0, float angle_y=0.0, float angle_z=0.0, bool negetive=false);
                 // void normalClusterExtraction();
                 std::vector<pcl::PointIndices> normalClusterExtraction(float smoothness = 3.0 / 180.0 * M_PI, float curvature = 0.1, int k_search = 90, 
                                                         int number_of_neighbours = 30, int min_cluster_size = 100, int max_cluster_size = 25000);

--- a/src/livox_hikcamera_cal/lib/pointcloud2_opr/point_cloud_process.cpp
+++ b/src/livox_hikcamera_cal/lib/pointcloud2_opr/point_cloud_process.cpp
@@ -133,13 +133,14 @@ namespace livox_hikcamera_cal::pointcloud2_opr
     }
 
 
-    void PointCloud2Proc::boxFilter(Eigen::Vector4f min_point, Eigen::Vector4f max_point)
+    void PointCloud2Proc::boxFilter(Eigen::Vector4f min_point, Eigen::Vector4f max_point, bool negetive)
     {
         pcl::CropBox<pcl::PointXYZI> boxFilter;
         pcl::PointCloud<pcl::PointXYZI>::Ptr tempCloud(new pcl::PointCloud<pcl::PointXYZI>);
         boxFilter.setInputCloud(this->processed_cloud);
         boxFilter.setMin(min_point);
         boxFilter.setMax(max_point);
+        boxFilter.setNegative(negetive);
 
         boxFilter.filter(*tempCloud);
         this->processedCloudUpdate(tempCloud);
@@ -147,7 +148,7 @@ namespace livox_hikcamera_cal::pointcloud2_opr
         return;
     }
     void PointCloud2Proc::boxFilter(Eigen::Vector3f box_center, float length_x, float length_y, float length_z,
-                                    float angle_x, float angle_y, float angle_z)
+                                    float angle_x, float angle_y, float angle_z, bool negetive)
     {
         pcl::CropBox<pcl::PointXYZI> boxFilter;
 
@@ -163,6 +164,8 @@ namespace livox_hikcamera_cal::pointcloud2_opr
         Eigen::Translation3f translate_to_center(box_center);
         
         boxFilter.setTransform(translate_to_center * rotate);
+
+        boxFilter.setNegative(negetive);
 
         pcl::PointCloud<pcl::PointXYZI>::Ptr tempCloud(new pcl::PointCloud<pcl::PointXYZI>);
         boxFilter.setInputCloud(this->processed_cloud);

--- a/src/livox_hikcamera_cal/lib/rviz_drawing.cpp
+++ b/src/livox_hikcamera_cal/lib/rviz_drawing.cpp
@@ -206,7 +206,7 @@ namespace livox_hikcamera_cal
                 it_objects_list_->second.action == visualization_msgs::Marker::DELETEALL ) 
             {
                 this->markers_.markers.push_back(it_objects_list_->second);
-                delete_objects.emplace_back(it_objects_list_); 
+                it_objects_list_ = this->objects_list_.erase(it_objects_list_);
             } 
             else 
             {
@@ -217,15 +217,14 @@ namespace livox_hikcamera_cal
         }
 
         this->pub_.publish(this->markers_);
-        this->markers_.markers.clear();
 
-        if(delete_objects.size() != 0)
-        {
-            for(auto delete_object:delete_objects)
-            {
-                this->objects_list_.erase(delete_object); 
-            }
-        }
+        // if(delete_objects.size() != 0)
+        // {
+        //     for(auto delete_object:delete_objects)
+        //     {
+        //         this->objects_list_.erase(delete_object); 
+        //     }
+        // }
     }
 
 

--- a/src/livox_hikcamera_cal/src/caliboard_cloud_detection_dynamic.cpp
+++ b/src/livox_hikcamera_cal/src/caliboard_cloud_detection_dynamic.cpp
@@ -43,12 +43,6 @@ int main(int argc, char *argv[])
 	RvizDrawing rviz_drawing;
 
 
-	ros::Publisher pub = rosHandle.advertise<visualization_msgs::MarkerArray>("livox_hikcamera_cal/rviz_drawing", 10);
-	visualization_msgs::Marker delete_marker;
-	delete_marker.ns = "delete_marker";
-	delete_marker.id = 0;
-	delete_marker.action = visualization_msgs::Marker::DELETEALL;
-
 	ros::Rate rate(30);
 
 	while(ros::ok())
@@ -61,6 +55,7 @@ int main(int argc, char *argv[])
 			continue;
 		}
 		pc_process.setCloud(pointcloud_SUB_PUB.getPointcloudXYZI());
+		pc_process.boxFilter(Eigen::Vector4f(-0.001, -0.001, -0.001, 1.0), Eigen::Vector4f(0.001, 0.001, 0.001, 1.0), true);
 		// ROS_INFO("%ld\n", pointcloud_SUB_PUB.getPointcloudXYZI()->size());
 		rqtCfg.FilterConfig = filterRecfg.getConfigure();
 		float x_max = rqtCfg.FilterConfig.x_max;
@@ -117,10 +112,9 @@ int main(int argc, char *argv[])
 
 		if(corners->size() == 0)
 		{
-			// rviz_drawing.deleteObject("corners");
-			// rviz_drawing.deleteObject("rect_lines");
-			pub.publish(delete_marker);
-			continue;
+			// rviz_drawing.deleteAllObject();
+			rviz_drawing.deleteObject("corners");
+			rviz_drawing.deleteObject("rect_lines");
 		}
 		else
 		{


### PR DESCRIPTION
Remove center point of livox point cloud: We found that the point cloud published by livox_ros_driver2 will have a point located at the origin of the coordinates. This can cause severe lag when using pcl to process the point cloud. We suggest to use CropBox to remove the regions Eigen::Vector4f(-0.001, -0.001, -0.001, 1.0), Eigen::Vector4f(0.001, 0.001, 0.001, 1.0), when using pcl to process the point cloud published by livox_ros_driver2.